### PR TITLE
replace bootmii IOS with priiloader

### DIFF
--- a/channel/channelapp/config.h
+++ b/channel/channelapp/config.h
@@ -46,8 +46,7 @@ void memstats(int reset);
 #define STUB_ADDR_MAGIC ((u64 *) 0x80002f00)
 #define STUB_ADDR_TITLE ((u64 *) 0x80002f08)
 
-#define BOOTMII_IOS 254
-#define TITLEID_BOOTMII (0x0000000100000000LL | BOOTMII_IOS)
+#define TITLEID_SYSMENU 0x0000000100000002LL
 
 #define PREFERRED IOS_GetPreferredVersion()
 #define UNCHANGED IOS_GetVersion()

--- a/channel/channelapp/i18n/dutch.po
+++ b/channel/channelapp/i18n/dutch.po
@@ -206,8 +206,8 @@ msgid "About"
 msgstr "Info"
 
 #: source/m_main.c:102
-msgid "Launch BootMii"
-msgstr "BootMii starten"
+msgid "Launch Priiloader"
+msgstr "Priiloader starten"
 
 #: source/m_main.c:106
 msgid "Exit to System Menu"

--- a/channel/channelapp/i18n/french.po
+++ b/channel/channelapp/i18n/french.po
@@ -210,8 +210,8 @@ msgid "About"
 msgstr "À propos de"
 
 #: source/m_main.c:102
-msgid "Launch BootMii"
-msgstr "Lancer BootMii"
+msgid "Launch Priiloader"
+msgstr "Lancer Priiloader"
 
 #: source/m_main.c:106
 msgid "Exit to System Menu"

--- a/channel/channelapp/i18n/german.po
+++ b/channel/channelapp/i18n/german.po
@@ -205,8 +205,8 @@ msgid "About"
 msgstr "Info"
 
 #: source/m_main.c:102
-msgid "Launch BootMii"
-msgstr "BootMii starten"
+msgid "Launch Priiloader"
+msgstr "Priiloader starten"
 
 #: source/m_main.c:106
 msgid "Exit to System Menu"

--- a/channel/channelapp/i18n/italian.po
+++ b/channel/channelapp/i18n/italian.po
@@ -212,8 +212,8 @@ msgid "About"
 msgstr "Informazioni"
 
 #: source/m_main.c:102
-msgid "Launch BootMii"
-msgstr "Lanciare BootMii"
+msgid "Launch Priiloader"
+msgstr "Lanciare Priiloader"
 
 #: source/m_main.c:106
 msgid "Exit to System Menu"

--- a/channel/channelapp/i18n/japanese.po
+++ b/channel/channelapp/i18n/japanese.po
@@ -210,8 +210,8 @@ msgid "About"
 msgstr "このアプリケーションについて"
 
 #: source/m_main.c:102
-msgid "Launch BootMii"
-msgstr "BootMiiを起動"
+msgid "Launch Priiloader"
+msgstr "Priiloaderを起動"
 
 #: source/m_main.c:106
 msgid "Exit to System Menu"

--- a/channel/channelapp/i18n/spanish.po
+++ b/channel/channelapp/i18n/spanish.po
@@ -207,8 +207,8 @@ msgid "About"
 msgstr "Acerca de"
 
 #: source/m_main.c:102
-msgid "Launch BootMii"
-msgstr "Lanzar BootMii"
+msgid "Launch Priiloader"
+msgstr "Lanzar Priiloader"
 
 #: source/m_main.c:106
 msgid "Exit to System Menu"

--- a/channel/channelapp/i18n/template.pot
+++ b/channel/channelapp/i18n/template.pot
@@ -208,7 +208,7 @@ msgid "About"
 msgstr ""
 
 #: source/m_main.c:102
-msgid "Launch BootMii"
+msgid "Launch Priiloader"
 msgstr ""
 
 #: source/m_main.c:106


### PR DESCRIPTION
This PR will replace the bootmii IOS button with Priiloader, as it is more often on wiis, and can go to bootmii IOS
